### PR TITLE
Refactor the returned data as an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ Python client for Farsight Security's [DNSDB API](https://api.dnsdb.info/).
  * sorting of results by last_seen
  * convert epoch to ISO 8601
  * normalize results with regard sensor or zone observation
- * DNSDB API Error codes returned in JSON data structure
- 
+ * returns an object with the following attributes:
+    * records
+    * status code
+    * error
+    * quota 
 
 ## Installation
 
@@ -21,42 +24,91 @@ pip install dnsdb
 
 ## Usage
 
-```python
-from dnsdb import Dnsdb
+### Setup
+```text
+>>> from dnsdb import Dnsdb
 
-api_key="12345"
-dnsdb = Dnsdb(api_key)
-
-results = dnsdb.search(name="fsi.io")
-results = dnsdb.search(name="mail.fsi.io", inverse=True)
-results = dnsdb.search(ip="104.244.14.108")
-results = dnsdb.search(ip="104.244.14.0/24")
-results = dnsdb.search(ip="2620:11c:f008::108")
-results = dnsdb.search(hexadecimal="36757a35")
-quota = dnsdb.quota()
+>>> api_key="12345"
+>>> dnsdb = Dnsdb(api_key)
 ```
 
-## Advanced Usage
+### Example 1
+```text
+>>> result = dnsdb.search(name="www.example.com")
 
-```python
+>>> pprint(result.status_code)
+200
+
+>>> pprint(result.error)
+None
+
+>>> pprint(result.records[0])
+{'bailiwick': 'example.com.',
+ 'count': 4213726,
+ 'rdata': ['93.184.216.34'],
+ 'rrname': 'www.example.com.',
+ 'rrtype': 'A',
+ 'source': 'sensor',
+ 'time_first': '2014-12-10T00:19:18Z',
+ 'time_last': '2019-03-05T14:37:31Z'}
+ 
+>>> pprint(result.quota)
+{'expires': None,
+ 'limit': '1000000',
+ 'remaining': '999970',
+ 'reset': '1551830400',
+ 'results_max': None}
+```
+
+### Example 2
+```text
+>>> result = dnsdb.search(name="hello.example.com")
+
+>>> pprint(result.status_code)
+404
+
+>>> pprint(result.error)
+{'code': 404, 'message': 'Error: no results found for query.'}
+
+>>> pprint(result.records)
+None
+
+>>> pprint(result.quota)
+{'expires': None,
+ 'limit': '1000000',
+ 'remaining': '999969',
+ 'reset': '1551830400',
+ 'results_max': None}
+```
+
+## More Usage
+```text
 from dnsdb import Dnsdb
 
 api_key="12345"
 dnsdb = Dnsdb(api_key)
 
-results = dnsdb.search(name="fsi.io", type="A")
-results = dnsdb.search(name="farsightsecurity.com", bailiwick="com.")
-results = dnsdb.search(name="fsi.io", wildcard_left=True)
-results = dnsdb.search(name="fsi", wildcard_right=True)
-results = dnsdb.search(name="fsi.io", sort=False)
-results = dnsdb.search(name="fsi.io", remote_limit=150000, return_limit=1000)
-results = dnsdb.search(name="fsi.io", time_last_after=1514764800)
+result = dnsdb.search(name="fsi.io")
+result = dnsdb.search(name="mail.fsi.io", inverse=True)
+result = dnsdb.search(ip="104.244.14.108")
+result = dnsdb.search(ip="104.244.14.0/24")
+result = dnsdb.search(ip="2620:11c:f008::108")
+result = dnsdb.search(hexadecimal="36757a35")
+result = dnsdb.search(name="fsi.io", type="A")
+result = dnsdb.search(name="farsightsecurity.com", bailiwick="com.")
+result = dnsdb.search(name="fsi.io", wildcard_left=True)
+result = dnsdb.search(name="fsi", wildcard_right=True)
+result = dnsdb.search(name="fsi.io", sort=False)
+result = dnsdb.search(name="fsi.io", remote_limit=150000, return_limit=1000)
+result = dnsdb.search(name="fsi.io", time_last_after=1514764800)
+result = dnsdb.search(name="fsi.io", epoch=True)
+result = dnsdb.quota()
 ```
 
 ## Contributing
-Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+Pull requests are welcome; for major changes, please open an issue first to discuss what you would like to change.
 
-Please make sure to update tests as appropriate.
+Please make sure to create and update tests as appropriate.
 
 ## License
 [MIT](https://choosealicense.com/licenses/mit/)

--- a/dnsdb/__init__.py
+++ b/dnsdb/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 __title__ = 'dnsdb'
-__version__ = '0.1.2'
+__version__ = '0.2.0'
 __author__ = 'Gabriel Iovino'
 __license__ = 'MIT'
 __copyright__ = 'Copyright (C) 2019 Gabriel Iovino'

--- a/playbook.yml
+++ b/playbook.yml
@@ -30,6 +30,8 @@
         - python3-venv
         - python3-pytest
         - pylint3
+        - black
+        - flake8
     - name: Install python modules with pip
       pip:
         name: "{{ modules }}"
@@ -38,3 +40,7 @@
         modules:
         - poetry
         - ipython
+    - name: Add Python Path to bashrc
+      lineinfile:
+        path: /home/vagrant/.bashrc
+        line: export PYTHONPATH=:/vagrant

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dnsdb"
-version = "0.1.2"
+version = "0.2.0"
 description = "Python client for Farsight Security's DNSDB API"
 license = "MIT"
 authors = ["Gabriel Iovino <giovino@gmail.com>"]

--- a/tests/live_test.py
+++ b/tests/live_test.py
@@ -5,6 +5,6 @@ api_key = ''
 
 dnsdb = Dnsdb(api_key)
 
-results = dnsdb.search(name="fsi.io")
+result = dnsdb.search(name="fsi.io")
 
-utils.debug(results, limit=2)
+utils.debug(result.records, limit=2)

--- a/tests/test_dnsdb.py
+++ b/tests/test_dnsdb.py
@@ -2,63 +2,86 @@ import pytest
 from dnsdb.dnsdb import utils
 from dnsdb import __version__
 
+RECORDS = [
+    {
+        "count": 57,
+        "time_first": 1381267249,
+        "time_last": 1417729108,
+        "rrname": "www.fsi.io.",
+        "rrtype": "A",
+        "bailiwick": "fsi.io.",
+        "rdata": ["66.160.140.76"],
+    },
+    {
+        "count": 4838,
+        "time_first": 1433657594,
+        "time_last": 1538006017,
+        "rrname": "www.fsi.io.",
+        "rrtype": "A",
+        "bailiwick": "fsi.io.",
+        "rdata": ["104.244.13.104"],
+    },
+]
+STATUS_CODE = 200
+ERROR = None
+QUOTA = {
+    "reset": "1551830400",
+    "results_max": None,
+    "expires": None,
+    "limit": "1000000",
+    "remaining": "999967",
+}
+
+
+class Result:
+    """
+    A object to store the results of a DNSDB Search and related meta data.
+    """
+
+    def __init__(self, records=None, status_code=None, error=None, quota=None):
+
+        self.status_code = status_code
+        self.records = records
+        self.error = error
+        self.quota = quota
+
 
 def test_version():
-    assert __version__ == '0.1.2'
+    assert __version__ == "0.2.0"
 
 
 def get_options():
 
     options = dict()
 
-    options['name'] = None
-    options['ip'] = None
-    options['hex'] = None
-    options['type'] = "ANY"
-    options['bailiwick'] = None
-    options['wildcard_left'] = None
-    options['wildcard_right'] = None
-    options['inverse'] = False
-    options['sort'] = True
-    options['return_limit'] = 10000
-    options['remote_limit'] = 50000
-    options['epoch'] = False
-    options['time_first_before'] = None
-    options['time_first_after'] = None
-    options['time_last_before'] = None
-    options['time_last_after'] = None
-    options['api_key'] = "12345"
-    options['server'] = "https://api.dnsdb.info"
+    options["name"] = None
+    options["ip"] = None
+    options["hex"] = None
+    options["type"] = "ANY"
+    options["bailiwick"] = None
+    options["wildcard_left"] = None
+    options["wildcard_right"] = None
+    options["inverse"] = False
+    options["sort"] = True
+    options["return_limit"] = 10000
+    options["remote_limit"] = 50000
+    options["epoch"] = False
+    options["time_first_before"] = None
+    options["time_first_after"] = None
+    options["time_last_before"] = None
+    options["time_last_after"] = None
+    options["api_key"] = "12345"
+    options["server"] = "https://api.dnsdb.info"
 
     return options
-
-
-def get_results():
-
-    results =[{"count" : 57,
-               "time_first":1381267249,
-               "time_last":1417729108,
-               "rrname":"www.fsi.io.",
-               "rrtype":"A",
-               "bailiwick":"fsi.io.",
-               "rdata":["66.160.140.76"]},
-              {"count":4838,
-               "time_first":1433657594,
-               "time_last":1538006017,
-               "rrname":"www.fsi.io.",
-               "rrtype":"A",
-               "bailiwick":"fsi.io.",
-               "rdata":["104.244.13.104"]}]
-
-    return results
 
 
 def test_wildcard_left_right_true():
 
     options = get_options()
-    options['name'] = "fsi.io"
-    options['wildcard_left'] = True
-    options['wildcard_right'] = True
+    options["name"] = "fsi.io"
+    options["wildcard_left"] = True
+    options["wildcard_right"] = True
 
     with pytest.raises(Exception):
         utils.validate_options(options)
@@ -67,284 +90,335 @@ def test_wildcard_left_right_true():
 def test_validate_options_wildcard_left_true_bare():
 
     options = get_options()
-    options['name'] = "fsi.io"
-    options['wildcard_left'] = True
+    options["name"] = "fsi.io"
+    options["wildcard_left"] = True
 
     options = utils.validate_options(options)
-    assert options['name'] == '*.fsi.io'
+    assert options["name"] == "*.fsi.io"
 
 
 def test_validate_options_wildcard_left_true_dot():
 
     options = get_options()
-    options['name'] = ".fsi.io"
-    options['wildcard_left'] = True
+    options["name"] = ".fsi.io"
+    options["wildcard_left"] = True
 
     options = utils.validate_options(options)
-    assert options['name'] == '*.fsi.io'
+    assert options["name"] == "*.fsi.io"
 
 
 def test_validate_options_wildcard_left_true_star_dot():
 
     options = get_options()
-    options['name'] = "*.fsi.io"
-    options['wildcard_left'] = True
+    options["name"] = "*.fsi.io"
+    options["wildcard_left"] = True
 
     options = utils.validate_options(options)
-    assert options['name'] == '*.fsi.io'
+    assert options["name"] == "*.fsi.io"
 
 
 def test_validate_options_wildcard_right_true_bare():
 
     options = get_options()
-    options['name'] = "fsi"
-    options['wildcard_right'] = True
+    options["name"] = "fsi"
+    options["wildcard_right"] = True
 
     options = utils.validate_options(options)
-    assert options['name'] == 'fsi.*'
+    assert options["name"] == "fsi.*"
 
 
 def test_validate_options_wildcard_right_true_dot():
 
     options = get_options()
-    options['name'] = "fsi."
-    options['wildcard_right'] = True
+    options["name"] = "fsi."
+    options["wildcard_right"] = True
 
     options = utils.validate_options(options)
-    assert options['name'] == 'fsi.*'
+    assert options["name"] == "fsi.*"
 
 
 def test_validate_options_wildcard_right_true_dot_star():
 
     options = get_options()
-    options['name'] = "fsi.*"
-    options['wildcard_right'] = True
+    options["name"] = "fsi.*"
+    options["wildcard_right"] = True
 
     options = utils.validate_options(options)
-    assert options['name'] == 'fsi.*'
+    assert options["name"] == "fsi.*"
 
 
 def test_build_uri_name():
 
-    VALID = 'https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY?limit=50000'
+    valid = "https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY?limit=50000"
 
     options = get_options()
-    options['name'] = 'fsi.io'
+    options["name"] = "fsi.io"
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_ip():
 
-    VALID = 'https://api.dnsdb.info/lookup/rdata/ip/104.244.14.108?limit=50000'
+    valid = "https://api.dnsdb.info/lookup/rdata/ip/104.244.14.108?limit=50000"
 
     options = get_options()
-    options['ip'] = '104.244.14.108'
+    options["ip"] = "104.244.14.108"
 
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_hex():
 
-    VALID = 'https://api.dnsdb.info/lookup/rdata/raw/36757a35?limit=50000'
+    valid = "https://api.dnsdb.info/lookup/rdata/raw/36757a35?limit=50000"
 
     options = get_options()
-    options['hex'] = '36757a35'
+    options["hex"] = "36757a35"
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_name_type():
 
-    VALID = 'https://api.dnsdb.info/lookup/rrset/name/fsi.io/A?limit=50000'
+    valid = "https://api.dnsdb.info/lookup/rrset/name/fsi.io/A?limit=50000"
 
     options = get_options()
-    options['name'] = 'fsi.io'
-    options['type'] = 'A'
+    options["name"] = "fsi.io"
+    options["type"] = "A"
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_name_bailiwick():
-
-    VALID = 'https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY/io.?limit=50000'
+    valid = "https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY/io.?limit" \
+            "=50000"
 
     options = get_options()
-    options['name'] = 'fsi.io'
-    options['bailiwick'] = 'io.'
+    options["name"] = "fsi.io"
+    options["bailiwick"] = "io."
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_name_type_bailiwick():
 
-    VALID = 'https://api.dnsdb.info/lookup/rrset/name/fsi.io/NS/io.?limit=50000'
+    valid = "https://api.dnsdb.info/lookup/rrset/name/fsi.io/NS/io.?limit=50000"
 
     options = get_options()
-    options['name'] = 'fsi.io'
-    options['type'] = 'NS'
-    options['bailiwick'] = 'io.'
+    options["name"] = "fsi.io"
+    options["type"] = "NS"
+    options["bailiwick"] = "io."
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_name_wildcard_left():
 
-    VALID = 'https://api.dnsdb.info/lookup/rrset/name/*.fsi.io/ANY?limit=50000'
+    valid = "https://api.dnsdb.info/lookup/rrset/name/*.fsi.io/ANY?limit=50000"
 
     options = get_options()
-    options['name'] = 'fsi.io'
-    options['wildcard_left'] = True
+    options["name"] = "fsi.io"
+    options["wildcard_left"] = True
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_name_wildcard_right():
 
-    VALID = 'https://api.dnsdb.info/lookup/rrset/name/fsi.*/ANY?limit=50000'
+    valid = "https://api.dnsdb.info/lookup/rrset/name/fsi.*/ANY?limit=50000"
 
     options = get_options()
-    options['name'] = 'fsi'
-    options['wildcard_right'] = True
+    options["name"] = "fsi"
+    options["wildcard_right"] = True
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_name_inverse():
 
-    VALID = 'https://api.dnsdb.info/lookup/rdata/name/fsi.io/ANY?limit=50000'
+    valid = "https://api.dnsdb.info/lookup/rdata/name/fsi.io/ANY?limit=50000"
 
     options = get_options()
-    options['name'] = 'fsi.io'
-    options['inverse'] = True
+    options["name"] = "fsi.io"
+    options["inverse"] = True
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_name_inverse_wildcard_left():
 
-    VALID = 'https://api.dnsdb.info/lookup/rdata/name/*.fsi.io/ANY?limit=50000'
+    valid = "https://api.dnsdb.info/lookup/rdata/name/*.fsi.io/ANY?limit=50000"
 
     options = get_options()
-    options['name'] = 'fsi.io'
-    options['inverse'] = True
-    options['wildcard_left'] = True
+    options["name"] = "fsi.io"
+    options["inverse"] = True
+    options["wildcard_left"] = True
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_name_type_inverse_wildcard_left():
 
-    VALID = 'https://api.dnsdb.info/lookup/rdata/name/*.fsi.io/MX?limit=50000'
+    valid = "https://api.dnsdb.info/lookup/rdata/name/*.fsi.io/MX?limit=50000"
 
     options = get_options()
-    options['name'] = 'fsi.io'
-    options['type'] = 'MX'
-    options['inverse'] = True
-    options['wildcard_left'] = True
+    options["name"] = "fsi.io"
+    options["type"] = "MX"
+    options["inverse"] = True
+    options["wildcard_left"] = True
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_name_remote_limit():
 
-    VALID = 'https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY?limit=25000'
+    valid = "https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY?limit=25000"
 
     options = get_options()
-    options['name'] = 'fsi.io'
-    options['remote_limit'] = 25000
+    options["name"] = "fsi.io"
+    options["remote_limit"] = 25000
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_name_time_first_before():
-
-    VALID = 'https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY?limit=50000&time_first_before=1540864340'
+    valid = (
+        "https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY?limit=50000"
+        "&time_first_before=1540864340"
+    )
 
     options = get_options()
-    options['name'] = 'fsi.io'
-    options['time_first_before'] = 1540864340
+    options["name"] = "fsi.io"
+    options["time_first_before"] = 1540864340
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
 
 
 def test_build_uri_name_time_all():
-
-    VALID = 'https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY?limit=50000&time_first_before=1540864340&time_first_after=1374093289&time_last_before=1540864340&time_last_after=1374093289'
+    valid = (
+        "https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY?limit=50000"
+        "&time_first_before=1540864340&time_first_after=1374093289"
+        "&time_last_before=1540864340&time_last_after=1374093289"
+    )
 
     options = get_options()
-    options['name'] = 'fsi.io'
-    options['time_first_before'] = 1540864340
-    options['time_first_after'] = 1374093289
-    options['time_last_before'] = 1540864340
-    options['time_last_after'] = 1374093289
+    options["name"] = "fsi.io"
+    options["time_first_before"] = 1540864340
+    options["time_first_after"] = 1374093289
+    options["time_last_before"] = 1540864340
+    options["time_last_after"] = 1374093289
 
     options = utils.validate_options(options)
     uri = utils.build_uri(options)
-    assert uri == VALID
+    assert uri == valid
+
+
+def test_get_quota_one():
+    response_headers = {'Server': 'nginx/1.10.3',
+                        'Date': 'Tue, 05 Mar 2019 18:58:04 GMT',
+                        'Content-Type': 'application/json',
+                        'Transfer-Encoding': 'chunked',
+                        'Connection': 'keep-alive', 'Vary': 'Accept-Encoding',
+                        'X-RateLimit-Limit': '1000000',
+                        'X-RateLimit-Remaining': '999954',
+                        'X-RateLimit-Reset': '1551830400',
+                        'Access-Control-Allow-Origin': '*',
+                        'Access-Control-Expose-Headers': 'X-RateLimit-Limit, '
+                                                         'X-RateLimit-Remaining, X-RateLimit-Reset',
+                        'Access-Control-Max-Age': '86400',
+                        'Access-Control-Allow-Credentials': 'true',
+                        'Access-Control-Allow-Methods': 'GET, POST',
+                        'Access-Control-Allow-Headers': 'Accept, '
+                                                        'Cache-Control, '
+                                                        'Pragma, Origin, '
+                                                        'Authorization, '
+                                                        'Cookie, '
+                                                        'Content-Type, '
+                                                        'X-API-Key',
+                        'Strict-Transport-Security': 'max-age=15768000',
+                        'Expires': '-1', 'Cache-Control': 'private, max-age=0',
+                        'Content-Encoding': 'gzip'}
+
+    quota = utils.get_quota(response_headers=response_headers)
+    assert quota['remaining'] == '999954'
+
+
+def test_get_quota_two():
+    rate_limit = {
+        'rate': {'reset': 1551830400, 'results_max': 1000000, 'limit': 1000000,
+                 'remaining': 999953}}
+
+    quota = utils.get_quota(rate_limit=rate_limit['rate'])
+    assert quota['remaining'] == 999953
+
+
+def test_normalize_rate():
+    rate_limit = {
+        'rate': {'reset': 'n/a', 'results_max': 1000000, 'expires': 1569888000,
+                 'limit': 25000, 'remaining': 24783}}
+
+    rate = utils.get_quota(rate_limit=rate_limit['rate'])
+    quota = utils.normalize_rate(rate)
+    assert quota['reset'] is None
 
 
 def test_post_process_name_sort():
 
-    VALID = 'test'
-
     options = get_options()
-    results = get_results()
-    options['name'] = 'fsi.io'
-    options['sort'] = True
-    options['epoch'] = True
+    result = Result(RECORDS, STATUS_CODE, ERROR, QUOTA)
+    options["name"] = "fsi.io"
+    options["sort"] = True
+    options["epoch"] = True
 
-    results = utils.post_process(options, results)
-    assert results[0]['time_last'] == 1538006017
+    result = utils.post_process(options, result)
+    records = result.records
+    assert records[0]["time_last"] == 1538006017
 
 
 def test_post_process_name_epoch():
 
-    VALID = 'test'
-
     options = get_options()
-    results = get_results()
-    options['name'] = 'fsi.io'
-    options['sort'] = True
-    options['epoch'] = False
+    result = Result(RECORDS, STATUS_CODE, ERROR, QUOTA)
+    options["name"] = "fsi.io"
+    options["sort"] = True
+    options["epoch"] = False
 
-    results = utils.post_process(options, results)
-    assert results[0]['time_last'] == "2018-09-26T23:53:37Z"
+    result = utils.post_process(options, result)
+    records = result.records
+    assert records[0]["time_last"] == "2018-09-26T23:53:37Z"
 
 
 def test_post_process_name_return_limit():
 
-    VALID = 'test'
-
     options = get_options()
-    results = get_results()
-    options['name'] = 'fsi.io'
-    options['return_limit'] = 1
+    result = Result(RECORDS, STATUS_CODE, ERROR, QUOTA)
+    options["name"] = "fsi.io"
+    options["return_limit"] = 1
 
-    results = utils.post_process(options, results)
-    assert len(results) == 1
+    result = utils.post_process(options, result)
+    records = result.records
+    assert len(records) == 1


### PR DESCRIPTION
This is a major refactor that changes most data structures returned.

Changes:
    1. dnsdb.search() returns an object
    2. dnsdb.quota() returns an object
    3. The object has the following attributes:
        * records
        * status_code
        * error
        * quota
    4. obj.quota is a normalized data structure compared to the raw api
    5. obj.error data structure has changed
    6. obj.status_code is new
    7. obj.records is the same list of dicts as before