### PR TITLE
Add support for human readable date/time

### DIFF
--- a/dnsdb/dnsdb.py
+++ b/dnsdb/dnsdb.py
@@ -142,7 +142,7 @@ class Dnsdb:
         options["api_key"] = self.api_key
         options["server"] = self.server
 
-        options = utils.validate_options(options)
+        options = utils.pre_process(options)
 
         uri = utils.build_uri(options)
 

--- a/dnsdb/utils.py
+++ b/dnsdb/utils.py
@@ -3,6 +3,8 @@
 Utility functions needed by the DNSDB module
 """
 
+from dateutil.parser import parse
+
 
 def build_uri(options):
     """
@@ -27,12 +29,10 @@ def build_path(options):
     """
     if options["name"]:
         if options["inverse"]:
-            path = "/lookup/rdata/name/{}/{}".format(options["name"],
-                                                     options["type"])
+            path = "/lookup/rdata/name/{}/{}".format(options["name"], options["type"])
             return path
         else:
-            path = "/lookup/rrset/name/{}/{}".format(options["name"],
-                                                     options["type"])
+            path = "/lookup/rrset/name/{}/{}".format(options["name"], options["type"])
 
             if options["bailiwick"]:
                 path += "/{}".format(options["bailiwick"])
@@ -161,8 +161,7 @@ def epoch_to_timestamp(records):
         timestamp_keys = ["time_first", "time_last"]
         for key in timestamp_keys:
             if key in record:
-                record[key] = datetime.fromtimestamp(
-                    record[key]).isoformat() + "Z"
+                record[key] = datetime.fromtimestamp(record[key]).isoformat() + "Z"
     return records
 
 
@@ -219,8 +218,7 @@ def validate_wildcard_left(name):
 
     if name[-1] == "*":
         raise Exception(
-            "Wildcard left lookup cannot end with an asterisk on " "the right "
-            "side"
+            "Wildcard left lookup cannot end with an asterisk on " "the right " "side"
         )
 
     # Correct wildcard syntax, do nothing
@@ -244,8 +242,7 @@ def validate_wildcard_right(name):
 
     if name[0] == "*":
         raise Exception(
-            "Wildcard right lookup cannot start with an asterisk " "on the "
-            "left side"
+            "Wildcard right lookup cannot start with an asterisk " "on the " "left side"
         )
 
     # Correct wildcard syntax, do nothing
@@ -309,3 +306,42 @@ def normalize_rate(rate):
         if rate[key] == "n/a":
             rate[key] = None
     return rate
+
+
+def pre_process(options):
+    """
+    Function to initial the pre-processing of specified options
+
+    :param options: dictionary
+    :return: dictionary
+    """
+
+    options = validate_options(options)
+
+    if options["epoch"] is False:
+        options = parse_date(options)
+
+    return options
+
+
+def parse_date(options):
+    """
+    Function to convert human readable date / time to epoch time
+
+    :param options: dictionary
+    :return: dictionary
+    """
+
+    options_time = [
+        "time_first_before",
+        "time_first_after",
+        "time_last_before",
+        "time_last_after",
+    ]
+
+    for time_field in options_time:
+        if options[time_field]:
+            dt = parse(options[time_field])
+            options[time_field] = int(dt.timestamp())
+
+    return options

--- a/poetry.lock
+++ b/poetry.lock
@@ -94,6 +94,17 @@ six = ">=1.10.0"
 
 [[package]]
 category = "main"
+description = "Extensions to the standard Python datetime module"
+name = "python-dateutil"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.8.0"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
 optional = false
@@ -107,7 +118,7 @@ idna = ">=2.5,<2.9"
 urllib3 = ">=1.21.1,<1.25"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
@@ -123,7 +134,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
 version = "1.24.1"
 
 [metadata]
-content-hash = "6533985ba40468ee2bf2dad33c4e34d6aa9df53b1a19f03a96c7d513828e2b64"
+content-hash = "10e4bf2b4ca0804bc4e04e8f753994b9d081cba382533d72cbdd9c070b3b430e"
 python-versions = "^3.6"
 
 [metadata.hashes]
@@ -137,6 +148,7 @@ more-itertools = ["38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d652
 pluggy = ["447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095", "bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"]
 py = ["bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694", "e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"]
 pytest = ["3f193df1cfe1d1609d4c583838bea3d532b18d6160fd3f55c9447fdca30848ec", "e246cf173c01169b9617fc07264b7b1316e78d7a650055235d6d897bc80d9660"]
+python-dateutil = ["7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb", "c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"]
 requests = ["502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e", "7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"]
 six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
 urllib3 = ["61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39", "de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ keywords = ["security"]
 [tool.poetry.dependencies]
 python = "^3.6"
 requests = "^2.21"
+python-dateutil = "^2.8"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/tests/live_test.py
+++ b/tests/live_test.py
@@ -7,4 +7,4 @@ dnsdb = Dnsdb(api_key)
 
 result = dnsdb.search(name="fsi.io")
 
-utils.debug(result.records, limit=2)
+print(result.rescords[0])

--- a/tests/test_dnsdb.py
+++ b/tests/test_dnsdb.py
@@ -196,8 +196,7 @@ def test_build_uri_name_type():
 
 
 def test_build_uri_name_bailiwick():
-    valid = "https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY/io.?limit" \
-            "=50000"
+    valid = "https://api.dnsdb.info/lookup/rrset/name/fsi.io/ANY/io.?limit" "=50000"
 
     options = get_options()
     options["name"] = "fsi.io"
@@ -338,52 +337,67 @@ def test_build_uri_name_time_all():
 
 
 def test_get_quota_one():
-    response_headers = {'Server': 'nginx/1.10.3',
-                        'Date': 'Tue, 05 Mar 2019 18:58:04 GMT',
-                        'Content-Type': 'application/json',
-                        'Transfer-Encoding': 'chunked',
-                        'Connection': 'keep-alive', 'Vary': 'Accept-Encoding',
-                        'X-RateLimit-Limit': '1000000',
-                        'X-RateLimit-Remaining': '999954',
-                        'X-RateLimit-Reset': '1551830400',
-                        'Access-Control-Allow-Origin': '*',
-                        'Access-Control-Expose-Headers': 'X-RateLimit-Limit, '
-                                                         'X-RateLimit-Remaining, X-RateLimit-Reset',
-                        'Access-Control-Max-Age': '86400',
-                        'Access-Control-Allow-Credentials': 'true',
-                        'Access-Control-Allow-Methods': 'GET, POST',
-                        'Access-Control-Allow-Headers': 'Accept, '
-                                                        'Cache-Control, '
-                                                        'Pragma, Origin, '
-                                                        'Authorization, '
-                                                        'Cookie, '
-                                                        'Content-Type, '
-                                                        'X-API-Key',
-                        'Strict-Transport-Security': 'max-age=15768000',
-                        'Expires': '-1', 'Cache-Control': 'private, max-age=0',
-                        'Content-Encoding': 'gzip'}
+    response_headers = {
+        "Server": "nginx/1.10.3",
+        "Date": "Tue, 05 Mar 2019 18:58:04 GMT",
+        "Content-Type": "application/json",
+        "Transfer-Encoding": "chunked",
+        "Connection": "keep-alive",
+        "Vary": "Accept-Encoding",
+        "X-RateLimit-Limit": "1000000",
+        "X-RateLimit-Remaining": "999954",
+        "X-RateLimit-Reset": "1551830400",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "X-RateLimit-Limit, "
+        "X-RateLimit-Remaining, X-RateLimit-Reset",
+        "Access-Control-Max-Age": "86400",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Methods": "GET, POST",
+        "Access-Control-Allow-Headers": "Accept, "
+        "Cache-Control, "
+        "Pragma, Origin, "
+        "Authorization, "
+        "Cookie, "
+        "Content-Type, "
+        "X-API-Key",
+        "Strict-Transport-Security": "max-age=15768000",
+        "Expires": "-1",
+        "Cache-Control": "private, max-age=0",
+        "Content-Encoding": "gzip",
+    }
 
     quota = utils.get_quota(response_headers=response_headers)
-    assert quota['remaining'] == '999954'
+    assert quota["remaining"] == "999954"
 
 
 def test_get_quota_two():
     rate_limit = {
-        'rate': {'reset': 1551830400, 'results_max': 1000000, 'limit': 1000000,
-                 'remaining': 999953}}
+        "rate": {
+            "reset": 1551830400,
+            "results_max": 1000000,
+            "limit": 1000000,
+            "remaining": 999953,
+        }
+    }
 
-    quota = utils.get_quota(rate_limit=rate_limit['rate'])
-    assert quota['remaining'] == 999953
+    quota = utils.get_quota(rate_limit=rate_limit["rate"])
+    assert quota["remaining"] == 999953
 
 
 def test_normalize_rate():
     rate_limit = {
-        'rate': {'reset': 'n/a', 'results_max': 1000000, 'expires': 1569888000,
-                 'limit': 25000, 'remaining': 24783}}
+        "rate": {
+            "reset": "n/a",
+            "results_max": 1000000,
+            "expires": 1569888000,
+            "limit": 25000,
+            "remaining": 24783,
+        }
+    }
 
-    rate = utils.get_quota(rate_limit=rate_limit['rate'])
+    rate = utils.get_quota(rate_limit=rate_limit["rate"])
     quota = utils.normalize_rate(rate)
-    assert quota['reset'] is None
+    assert quota["reset"] is None
 
 
 def test_post_process_name_sort():
@@ -422,3 +436,39 @@ def test_post_process_name_return_limit():
     result = utils.post_process(options, result)
     records = result.records
     assert len(records) == 1
+
+
+def test_epoch_timestamp():
+
+    timestamp = 1546300800
+
+    options = get_options()
+    options["time_last_after"] = timestamp
+    options["epoch"] = True
+
+    options = utils.pre_process(options)
+    assert options["time_last_after"] == 1546300800
+
+
+def test_human_date_one():
+
+    date = "2019-01-01"
+
+    options = get_options()
+    options["time_last_after"] = date
+    options["epoch"] = False
+
+    options = utils.pre_process(options)
+    assert options["time_last_after"] == 1546300800
+
+
+def test_human_date_two():
+
+    date = "2018-06-13T02:05:36Z"
+
+    options = get_options()
+    options["time_last_after"] = date
+    options["epoch"] = False
+
+    options = utils.pre_process(options)
+    assert options["time_last_after"] == 1528855536


### PR DESCRIPTION
Resolve issue #1 - Support ISO 8601 formats for time filters
https://github.com/giovino/fsi-dnsdb/issues/1

Used parse from dateutil.parser to accept human readable dates
on time filters.